### PR TITLE
Fix gradient check in longformer tests

### DIFF
--- a/tests/test_longformer.py
+++ b/tests/test_longformer.py
@@ -11,7 +11,7 @@ if path not in sys.path:
 
 from longformer import Longformer, LongformerForMaskedLM, LongformerForSequenceClassification
 from config import LongformerConfig
-from sliding_chunks import pad_to_window_size
+from src.models.banded_gemm import pad_to_window_size
 
 class TestLongformer(unittest.TestCase):
     
@@ -69,10 +69,9 @@ class TestLongformer(unittest.TestCase):
         loss = output_tensor[0].sum()
         loss.backward()
         optimizer.step()
-        
-        for param, name in zip(model.parameters(), model.state_dict()):
-            if param.grad is None:
-                print(name)
+
+        has_grad = any(param.grad is not None for param in model.parameters())
+        self.assertTrue(has_grad, "No gradients found for model parameters")
             
 if __name__ == "__main__":
     unittest.main() 


### PR DESCRIPTION
## Summary
- import pad_to_window_size from banded_gemm
- assert that at least one parameter received a gradient

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683f662513548322864a0457552c871b