### PR TITLE
Fix CrossEntropyLoss call in DistilBERT validation

### DIFF
--- a/src/models/distil_bert.py
+++ b/src/models/distil_bert.py
@@ -327,7 +327,7 @@ class MyDistiBertClassification(nn.Module):
         attention_mask = batch['attention_mask']
         labels = batch['labels']
         outputs = self(input_ids, attention_mask)
-        loss = nn.CrossEntropyLoss(outputs.view(-1, self.num_labels), labels.view(-1))
+        loss = nn.CrossEntropyLoss()(outputs.view(-1, self.num_labels), labels.view(-1))
         return loss, outputs
     
 class MyDistilBertForQuestionAnswering(nn.Module):


### PR DESCRIPTION
## Summary
- fix `validation_step` in `MyDistiBertClassification` to correctly instantiate `CrossEntropyLoss`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683f6623ae4c83228c20e1103aa1c89a